### PR TITLE
Fix Type Export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-proxies",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Solid.js library adding signaling to built-in non-primitives",
   "info": "This package provides signaled versions of Javascript's built-in objects. Thanks to it, all theirs properties will be automatically tracked while using standard API. That means all operations like array's `push`, `slice` or direct index access `track['me']` will only trigger an update of specific values. The granular reactivity will make sure your effects will not rerun without a need.",
   "homepage": "https://github.com/Exelord/solid-proxies",
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "import": "./dist/solid-proxies.js",
-      "require": "./dist/solid-proxies.cjs"
+      "require": "./dist/solid-proxies.cjs",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-proxies",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Solid.js library adding signaling to built-in non-primitives",
   "info": "This package provides signaled versions of Javascript's built-in objects. Thanks to it, all theirs properties will be automatically tracked while using standard API. That means all operations like array's `push`, `slice` or direct index access `track['me']` will only trigger an update of specific values. The granular reactivity will make sure your effects will not rerun without a need.",
   "homepage": "https://github.com/Exelord/solid-proxies",
@@ -11,15 +11,9 @@
       "url": "https://exelord.com"
     }
   ],
-  "keywords": [
-    "solidhack",
-    "best_ecosystem",
-    "solidjs"
-  ],
+  "keywords": ["solidhack", "best_ecosystem", "solidjs"],
   "license": "MIT",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "./dist/solid-proxies.cjs",
   "module": "./dist/solid-proxies.js",
   "types": "./dist/types/index.d.ts",
@@ -57,9 +51,7 @@
       "releaseName": "v${version}"
     },
     "hooks": {
-      "before:init": [
-        "vitest run"
-      ]
+      "before:init": ["vitest run"]
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
When trying to import this module the following error occurs:
```error
Could not find a declaration file for module 'solid-proxies'. './node_modules/solid-proxies/dist/solid-proxies.js' implicitly has an 'any' type.
  There are types at './node_modules/solid-proxies/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports".
  The 'solid-proxies' library may need to update its package.json or typings. ts(7016)
 ```

This Pr Fixes that